### PR TITLE
feat: add support for sort_all_objects on Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 workspace = { members = ["fuzz"] }
 [package]
 name = "serde_json_bytes"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Geoffroy Couprie <geoffroy@apollographql.com>"]

--- a/src/map.rs
+++ b/src/map.rs
@@ -284,6 +284,12 @@ impl Map<ByteString, Value> {
     {
         self.map.retain(f);
     }
+
+    #[inline]
+    pub fn sort_keys(&mut self) {
+        #[cfg(feature = "preserve_order")]
+        self.map.sort_unstable_keys();
+    }
 }
 
 #[allow(clippy::derivable_impls)] // clippy bug: https://github.com/rust-lang/rust-clippy/issues/7655

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -844,7 +844,7 @@ impl Value {
     /// If serde_json's "preserve_order" feature is not enabled, this method
     /// does no work because all JSON maps are always kept in a sorted state.
     ///
-    /// If serde_json's "preserve_order" feature is enabled, this method
+    /// If serde_json_bytes's "preserve_order" feature is enabled, this method
     /// destroys the original source order or insertion order of the JSON
     /// objects in favor of an alphanumerical order that matches how a BTreeMap
     /// with the same contents would be ordered.

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1011,3 +1011,20 @@ where
 {
     T::deserialize(value)
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::json;
+
+    use super::*;
+
+    #[test]
+    fn test_sort_all_objects() {
+        let mut val = json!({"id1": true, "id2": false});
+        val.sort_all_objects();
+        let mut second_val = json!({"id2": false, "id1": true});
+        second_val.sort_all_objects();
+
+        assert_eq!(val.to_string(), second_val.to_string());
+    }
+}

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -837,6 +837,32 @@ impl Value {
     pub fn take(&mut self) -> Value {
         mem::replace(self, Value::Null)
     }
+
+    /// Reorders the entries of all `Value::Object` nested within this JSON
+    /// value according to `str`'s usual ordering.
+    ///
+    /// If serde_json's "preserve_order" feature is not enabled, this method
+    /// does no work because all JSON maps are always kept in a sorted state.
+    ///
+    /// If serde_json's "preserve_order" feature is enabled, this method
+    /// destroys the original source order or insertion order of the JSON
+    /// objects in favor of an alphanumerical order that matches how a BTreeMap
+    /// with the same contents would be ordered.
+    pub fn sort_all_objects(&mut self) {
+        #[cfg(feature = "preserve_order")]
+        {
+            match self {
+                Value::Object(map) => {
+                    map.sort_keys();
+                    map.values_mut().for_each(Value::sort_all_objects);
+                }
+                Value::Array(list) => {
+                    list.iter_mut().for_each(Value::sort_all_objects);
+                }
+                _ => {}
+            }
+        }
+    }
 }
 
 /// The default value is `Value::Null`.


### PR DESCRIPTION
Provide https://docs.rs/serde_json/latest/serde_json/value/enum.Value.html#method.sort_all_objects as implemented on `serde_json`