### PR TITLE
ci: add release automation for serde_json_bytes

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,81 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "New version to release, e.g. 0.2.6 (bare semver, no leading 'v')"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release:
+    name: Bump version and open release PR
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      VERSION: ${{ inputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Validate version is bare semver
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::'$VERSION' is not a valid bare semver version (expected e.g. 0.2.6)."
+            exit 1
+          fi
+
+      - name: Reject if this version is already tagged
+        run: |
+          if git rev-parse -q --verify "refs/tags/$VERSION" >/dev/null; then
+            echo "::error::Tag '$VERSION' already exists."
+            exit 1
+          fi
+
+      - name: Reject if not greater than the published crates.io version
+        run: |
+          published=$(curl -sf https://crates.io/api/v1/crates/serde_json_bytes | python3 -c "import json,sys; print(json.load(sys.stdin)['crate']['max_version'])")
+          echo "Currently published on crates.io: $published"
+          python3 - "$VERSION" "$published" <<'PYEOF'
+          import sys
+          new = tuple(int(x) for x in sys.argv[1].split("."))
+          cur = tuple(int(x) for x in sys.argv[2].split("."))
+          if new <= cur:
+              print(f"::error::{sys.argv[1]} is not greater than the currently published version {sys.argv[2]}")
+              sys.exit(1)
+          PYEOF
+
+      - name: Bump version in Cargo.toml
+        run: |
+          sed -i -E "s/^version = \".*\"\$/version = \"$VERSION\"/" Cargo.toml
+          grep -m1 '^version = ' Cargo.toml
+
+      - name: Sanity-check the bump took effect
+        run: |
+          actual=$(cargo pkgid --manifest-path Cargo.toml | sed -E 's/.*[#:]//')
+          if [ "$actual" != "$VERSION" ]; then
+            echo "::error::Cargo.toml version is '$actual' after bump, expected '$VERSION'."
+            exit 1
+          fi
+
+      - name: Create branch, commit, and open PR
+        run: |
+          branch="release/$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add Cargo.toml
+          git commit -m "$VERSION"
+          git push origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore: release $VERSION" \
+            --body "Bumps \`Cargo.toml\` to \`$VERSION\`. Merging this PR does **not** publish the crate — after merge, run the **Publish Release** workflow to tag, \`cargo publish\`, and create the GitHub Release."

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,62 @@
+name: Publish Release
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+
+jobs:
+  publish:
+    name: Tag, publish to crates.io, and create GitHub Release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: write
+      id-token: write # required to mint a short-lived crates.io token via OIDC
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Read version from Cargo.toml
+        id: version
+        run: |
+          version=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/^version = "(.*)"$/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Publishing version: $version"
+
+      - name: Reject if this version is already published on crates.io
+        run: |
+          version="${{ steps.version.outputs.version }}"
+          if curl -sf -o /dev/null "https://crates.io/api/v1/crates/serde_json_bytes/$version"; then
+            echo "::error::serde_json_bytes $version is already published on crates.io."
+            exit 1
+          fi
+
+      - name: Create and push tag
+        run: |
+          # Force-create/push: a previous run may have already tagged this commit
+          # before failing at a later step (e.g. cargo publish). That's fine as
+          # long as the version above isn't actually live on crates.io yet.
+          # (Lightweight tag, so no git identity/config needed here.)
+          git tag -f "${{ steps.version.outputs.version }}"
+          git push --force origin "refs/tags/${{ steps.version.outputs.version }}"
+
+      - name: Authenticate with crates.io (Trusted Publishing)
+        uses: rust-lang/crates-io-auth-action@v1
+        id: auth
+
+      - name: Publish to crates.io
+        run: cargo publish -p serde_json_bytes
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+
+      - name: Create GitHub Release
+        run: |
+          gh release create "${{ steps.version.outputs.version }}" \
+            --title "${{ steps.version.outputs.version }}" \
+            --generate-notes

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,55 @@
+# Releasing `serde_json_bytes`
+
+This crate is released to [crates.io](https://crates.io/crates/serde_json_bytes) via two
+manually-triggered GitHub Actions workflows: **Prepare Release** and **Publish Release**.
+Publishing uses crates.io's [Trusted Publishing](https://crates.io/docs/trusted-publishing) —
+GitHub Actions OIDC authentication, no stored API token to create or rotate.
+
+## Who can release
+
+**Publish Release** runs under the `release` GitHub Environment, configured (in repo
+Settings → Environments) to require approval from a specific list of reviewers, and
+restricted to protected branches only (in practice, `main`). Anyone with write access can
+*trigger* `workflow_dispatch`, but the job then pauses for reviewer approval, and can only
+run at all from `main` — both enforced by GitHub itself, independent of the workflow file's
+contents.
+
+**Prepare Release** isn't environment-gated — it can't publish or tag anything on its own,
+it only opens a PR, so its real backstop is the same required review that already gates
+every other merge into `main`.
+
+## Versioning
+
+Versions are bare semver with no `v` prefix (e.g. `0.2.6`, not `v0.2.6`), matching all
+existing tags (`0.1.0` through `0.2.4`).
+
+## Step by step
+
+1. Decide the next version number based on what's merged to `main` since the last release.
+2. Go to the **Actions** tab → **Prepare Release** → **Run workflow**, enter the version
+   (e.g. `0.2.6`), and run it.
+   - This validates the version, bumps `Cargo.toml` on a new `release/<version>` branch,
+     and opens a PR titled `chore: release <version>`.
+3. Review and merge that PR into `main`.
+   - Note: GitHub's loop-prevention means the `rust.yaml` CI job (fmt/clippy/build/test)
+     likely won't automatically run against this bot-authored PR. That's expected and
+     won't block the merge, since this repo's required status checks are the CircleCI
+     security scans, not that job.
+4. Go to the **Actions** tab → **Publish Release** → **Run workflow** (no inputs needed)
+   and run it.
+   - This requires approval from a `@apollographql/graphos` reviewer before it proceeds,
+     since it runs under the `release` Environment's required-reviewer protection.
+   - Once approved, it reads the version from `Cargo.toml` on `main`, creates and pushes a
+     matching git tag, runs `cargo publish`, and creates a GitHub Release with
+     auto-generated release notes.
+5. Verify: check the [crates.io page](https://crates.io/crates/serde_json_bytes), the new
+   git tag, and the new GitHub Release.
+
+## Troubleshooting
+
+If **Publish Release** fails partway through (e.g. `cargo publish` errors out after the tag
+was already pushed), it's safe to just re-run the workflow. It only refuses to proceed if
+the version in `Cargo.toml` is already live on crates.io — it doesn't care whether the tag
+already exists, and will happily re-point it at the current `main` HEAD on retry. Once a
+version is actually published, crates.io publishes can't be undone, only
+[yanked](https://doc.rust-lang.org/cargo/commands/cargo-yank.html).


### PR DESCRIPTION
## Summary

There was previously no automation and nothing written down for the release process of this crate — releases were done by hand (manual `Cargo.toml` bump, manual git tag, presumably manual `cargo publish`).

Adds two manually-triggered GitHub Actions workflows plus `RELEASING.md` documenting the resulting process:

- **Prepare Release** (`workflow_dispatch`, takes a `version` input): validates the version, bumps `Cargo.toml` on a new `release/<version>` branch, and opens a `chore: release <version>` PR into `main`. Not environment-gated — it can't publish or tag anything, so its backstop is the same required review that already gates merges into `main`.
- **Publish Release** (`workflow_dispatch`, no inputs): reads the version from `Cargo.toml` on `main`, tags it, publishes to crates.io via [Trusted Publishing](https://crates.io/docs/trusted-publishing) (OIDC — no stored token), and creates a GitHub Release with auto-generated notes. Runs under the `release` Environment (required reviewers, protected-branches-only), since this is the one that actually matters from a security standpoint.

## One-time setup still needed

1. **crates.io Trusted Publisher config** — someone who's currently an owner of `serde_json_bytes` on crates.io needs to add a trusted publisher under the crate's settings:
   - Repository owner: `apollographql`
   - Repository name: `serde_json_bytes`
   - Workflow filename: `publish-release.yml`
   - Environment name: `release`

   The environment name matters here beyond just documentation: pinning it means crates.io's OIDC verification requires the token to carry a genuine `release`-environment claim, which can only be present if the job actually went through that Environment's protection rules. That's what makes the gate hold even against someone editing the workflow file on an arbitrary branch to try to skip it.

2. **Known drift**: `Cargo.toml` was bumped to `0.2.5` and that version is already live on crates.io, but no matching `0.2.5` git tag was ever created — so `git tag --list` and crates.io are one release out of sync. Worth retroactively tagging the commit that made that bump (`101af94`) as `0.2.5` before running the next release through this new process, so tags stay meaningful going forward. Not required — Prepare Release checks the next version against crates.io's published version, not the latest git tag, specifically because of this drift — but recommended cleanup.

The `release` Environment itself (required reviewers, protected branches only) is already set up.

## Test plan

- [x] Both workflow files validated with `actionlint` (clean)
- [ ] First real `workflow_dispatch` of each workflow, after merge, is the actual end-to-end verification — not something achievable pre-merge