### PR TITLE
ci: set a User-Agent on crates.io API calls in release workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,6 +19,9 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       VERSION: ${{ inputs.version }}
+      # crates.io returns 403 unless the User-Agent identifies the caller —
+      # curl's default doesn't qualify, so every API call below sets one.
+      CRATES_IO_UA: "serde_json_bytes-release (github.com/apollographql/serde_json_bytes)"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,7 +44,9 @@ jobs:
 
       - name: Reject if not greater than the published crates.io version
         run: |
-          published=$(curl -sf https://crates.io/api/v1/crates/serde_json_bytes | python3 -c "import json,sys; print(json.load(sys.stdin)['crate']['max_version'])")
+          response=$(curl -sS --fail-with-body -H "User-Agent: $CRATES_IO_UA" \
+            https://crates.io/api/v1/crates/serde_json_bytes)
+          published=$(printf '%s' "$response" | python3 -c "import json,sys; print(json.load(sys.stdin)['crate']['max_version'])")
           echo "Currently published on crates.io: $published"
           python3 - "$VERSION" "$published" <<'PYEOF'
           import sys

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -16,6 +16,9 @@ jobs:
       id-token: write # required to mint a short-lived crates.io token via OIDC
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # crates.io returns 403 unless the User-Agent identifies the caller —
+      # curl's default doesn't qualify, so every API call below sets one.
+      CRATES_IO_UA: "serde_json_bytes-release (github.com/apollographql/serde_json_bytes)"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -30,12 +33,29 @@ jobs:
           echo "Publishing version: $version"
 
       - name: Reject if this version is already published on crates.io
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          version="${{ steps.version.outputs.version }}"
-          if curl -sf -o /dev/null "https://crates.io/api/v1/crates/serde_json_bytes/$version"; then
-            echo "::error::serde_json_bytes $version is already published on crates.io."
-            exit 1
-          fi
+          # Check the status code explicitly rather than relying on curl's exit
+          # status: anything other than a clean 404 must block the release, so
+          # that a transient error or a rejected request can't read as "not
+          # published yet" and let the publish proceed.
+          code=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -H "User-Agent: $CRATES_IO_UA" \
+            "https://crates.io/api/v1/crates/serde_json_bytes/$VERSION")
+          case "$code" in
+            404)
+              echo "$VERSION is not yet published on crates.io — proceeding."
+              ;;
+            200)
+              echo "::error::serde_json_bytes $VERSION is already published on crates.io."
+              exit 1
+              ;;
+            *)
+              echo "::error::Unexpected status $code from crates.io while checking whether $VERSION is published."
+              exit 1
+              ;;
+          esac
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
The release automation added in #25 calls the crates.io API without a User-Agent header.  crates.io returns 403 for requests whose User-Agent does not identify the caller, and curl's default does not qualify — so both calls were failing, in different ways.

Prepare Release piped the empty 403 body into `python3` and died on a `JSONDecodeError`.  That is how this surfaced: the first real run of Prepare Release, for `0.2.6`, failed at that step.

Publish Release used `curl -sf` exit status to decide whether a version was already published.  A 403 makes curl exit non-zero, the `if` evaluates false, and the step concludes "not published" and carries on — so that guard has never actually worked, and it fails in the permissive direction.  That is the one I would rather not leave sitting there, since a re-run after a partial failure is exactly when it matters.

Sets an explicit User-Agent on both.  Also rewrites the Publish Release check to branch on the status code, so a clean 404 proceeds, a 200 blocks, and anything else blocks too rather than being read as "not published yet".

Checked against the live API: 403 with curl's default User-Agent, 200 with an explicit one.  With the fix, `0.2.6` reads 404 (would proceed) and `0.2.5` reads 200 (would block).  actionlint clean on both files.

Failed run that turned this up: https://github.com/apollographql/serde_json_bytes/actions/runs/31684342912