### PR TITLE
ci: read the bumped version from Cargo.toml instead of cargo pkgid

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -64,7 +64,11 @@ jobs:
 
       - name: Sanity-check the bump took effect
         run: |
-          actual=$(cargo pkgid --manifest-path Cargo.toml | sed -E 's/.*[#:]//')
+          # Read the manifest directly rather than via `cargo pkgid`, which
+          # requires a Cargo.lock — this crate is a library and doesn't commit
+          # one, so pkgid can never resolve on a fresh checkout. This also
+          # matches how Publish Release reads the version back.
+          actual=$(grep -m1 '^version = ' Cargo.toml | sed -E 's/^version = "(.*)"$/\1/')
           if [ "$actual" != "$VERSION" ]; then
             echo "::error::Cargo.toml version is '$actual' after bump, expected '$VERSION'."
             exit 1


### PR DESCRIPTION
Prepare Release fails its own sanity check immediately after bumping the version:

```
error: a Cargo.lock must exist for this command
Cargo.toml version is '' after bump, expected '0.2.6'.
```

`cargo pkgid` needs a `Cargo.lock`.  This crate is a library and does not commit one — `--locked` was deliberately dropped in f570e4f3 — so pkgid can never resolve on a fresh checkout, and `actual` came back empty every time.

Reads the manifest directly instead.  That is already how Publish Release reads the version back, so the two workflows now agree on the mechanism rather than each having their own.

Worth noting the bump step itself was fine — it ran correctly on the runner.  Only the check that follows it was broken, so this had no effect on what would have been published, just on getting there at all.

Checked on a scratch copy of `Cargo.toml`: bump takes `0.2.5` to `0.2.6`, the check reads back `0.2.6`, and the diff touches only the package version line.  actionlint clean.

Failed run: https://github.com/apollographql/serde_json_bytes/actions/runs/31685494089