### PR TITLE
docs: correct the release-PR CI note in RELEASING.md

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -20,8 +20,7 @@ every other merge into `main`.
 
 ## Versioning
 
-Versions are bare semver with no `v` prefix (e.g. `0.2.6`, not `v0.2.6`), matching all
-existing tags (`0.1.0` through `0.2.4`).
+Versions are bare semver with no `v` prefix — e.g. `0.2.6`, not `v0.2.6`.
 
 ## Step by step
 
@@ -31,10 +30,15 @@ existing tags (`0.1.0` through `0.2.4`).
    - This validates the version, bumps `Cargo.toml` on a new `release/<version>` branch,
      and opens a PR titled `chore: release <version>`.
 3. Review and merge that PR into `main`.
-   - Note: GitHub's loop-prevention means the `rust.yaml` CI job (fmt/clippy/build/test)
-     likely won't automatically run against this bot-authored PR. That's expected and
-     won't block the merge, since this repo's required status checks are the CircleCI
-     security scans, not that job.
+   - The PR is authored by `github-actions[bot]`, which GitHub treats specially: the
+     `rust.yaml` run is created but parked as `action_required` pending manual approval,
+     and CircleCI doesn't fire at all — so the required `gitleaks` and `semgrep` checks
+     are missing and the PR is blocked.
+   - Simplest fix is to push an empty commit to the release branch yourself. A push from
+     a human actor wakes both systems and everything goes green:
+     `git commit --allow-empty -m "chore: trigger CI on release/<version>" && git push`
+   - You also can't approve your own release PR, so merging needs either a second
+     `@apollographql/graphos` reviewer or an admin override.
 4. Go to the **Actions** tab → **Publish Release** → **Run workflow** (no inputs needed)
    and run it.
    - This requires approval from a `@apollographql/graphos` reviewer before it proceeds,

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -37,12 +37,13 @@ Versions are bare semver with no `v` prefix — e.g. `0.2.6`, not `v0.2.6`.
    - Simplest fix is to push an empty commit to the release branch yourself. A push from
      a human actor wakes both systems and everything goes green:
      `git commit --allow-empty -m "chore: trigger CI on release/<version>" && git push`
-   - You also can't approve your own release PR, so merging needs either a second
-     `@apollographql/graphos` reviewer or an admin override.
+   - You also can't approve your own release PR, so merging needs either another
+     reviewer or an admin override.
 4. Go to the **Actions** tab → **Publish Release** → **Run workflow** (no inputs needed)
    and run it.
-   - This requires approval from a `@apollographql/graphos` reviewer before it proceeds,
-     since it runs under the `release` Environment's required-reviewer protection.
+   - This requires approval from one of the `release` Environment's configured reviewers
+     before it proceeds, since it runs under that Environment's required-reviewer
+     protection. The reviewer list lives in Settings → Environments → `release`.
    - Once approved, it reads the version from `Cargo.toml` on `main`, creates and pushes a
      matching git tag, runs `cargo publish`, and creates a GitHub Release with
      auto-generated release notes.


### PR DESCRIPTION
Running the process for `0.2.6` showed step 3 was wrong in both directions, in the way most likely to strand whoever follows it next.

`rust.yaml` is not skipped — GitHub creates the run and parks it as `action_required` pending manual approval.  And CircleCI does not fire at all, so the required `gitleaks` and `semgrep` checks are absent and the PR *is* blocked, rather than merging cleanly as the note promised.

Documents what actually unblocks it: an empty commit pushed by a human wakes both systems, after which everything goes green and only the approval needs an override.  Also notes that the releaser cannot approve their own release PR, which is not obvious until you are staring at it.

Drops the tag enumeration from Versioning while here.  It restated the convention as a range (`0.1.0` through `0.2.4`) that goes stale on every single release — the example alongside it already carries the convention on its own, so bumping the range would just reset a clock rather than fix anything.

Observed on #28 and the run that published 0.2.6: https://github.com/apollographql/serde_json_bytes/actions/runs/31687391820